### PR TITLE
Fix PyTorch checkpointing multiple access to ctx.saved_tensor

### DIFF
--- a/phiml/backend/torch/_torch_backend.py
+++ b/phiml/backend/torch/_torch_backend.py
@@ -1144,8 +1144,11 @@ def construct_torch_custom_function(f: Callable, jit_f: Optional[Callable], f_ex
 
         @staticmethod
         def backward(ctx, *grad_args):  # Breakpoints not supported here
-            x = ctx.saved_tensors[:ctx.input_count]
-            y = ctx.saved_tensors[ctx.input_count:]
+            # Cache the saved_tensors, so it is only accessed once.
+            # This is a requirement for gradient checkpointing
+            ctx_tensors = ctx.saved_tensors
+            x = ctx_tensors[:ctx.input_count]
+            y = ctx_tensors[ctx.input_count:]
             if is_f_traced:
                 if not jit_g:
                     # backward pass can return None but that's not allowed in JIT functions


### PR DESCRIPTION
Hi,

Currently when using the PyTorch backend, PhiML does not support gradient checkpointing. An error will be thrown complaining `torch.utils.checkpoint.CheckpointError: torch.utils.checkpoint: Unpack is being triggered for a tensor that was already unpacked once. If you are calling ctx.saved_tensors in backward, make sure to do so only once. Otherwise please open an issue with details on your use case`.

This is because in _torch_backend, `TorchCustomFunction.backward()` accesses `ctx.saved_tensors` twice.

The issue can be fixed by accessing `ctx.saved_tensors` only once and caching it in a separate variable (see code change).

Please let me know if any of this does not make sense or if there's a better fix 😃 

Bellow is a simple use case / repro adapted from [Fluids_Tutorial.ipynb](https://github.com/tum-pbs/PhiFlow/blob/master/docs/Fluids_Tutorial.ipynb).

<details>

<summary>Checkpointing Error Repro Example</summary>

```python
from torch.utils import checkpoint
from phi.torch.flow import *

INFLOW_LOCATION = tensor([(4, 5), (8, 5), (12, 5), (16, 5)], batch('inflow_loc'), channel(vector='x,y'))
INFLOW = 0.6 * CenteredGrid(Sphere(center=INFLOW_LOCATION, radius=3), extrapolation.BOUNDARY, x=32, y=40,
                            bounds=Box(x=32, y=40))


def step(smoke: CenteredGrid, velocity: StaggeredGrid):
    smoke = advect.mac_cormack(smoke, velocity, dt=1) + INFLOW
    buoyancy_force = smoke * (0, 0.5) @ velocity
    velocity = advect.semi_lagrangian(velocity, velocity, dt=1) + buoyancy_force
    velocity, _ = fluid.make_incompressible(velocity)
    return smoke, velocity


def simulate(smoke: CenteredGrid, velocity: StaggeredGrid):
    for _ in range(5):
        # smoke, velocity = step(smoke, velocity)
        # THIS WILL CAUSE ISSUE
        smoke, velocity = checkpoint.checkpoint(step, smoke=smoke, velocity=velocity, use_reentrant=False)
    loss = math.sum(field.l2_loss(diffuse.explicit(smoke - field.stop_gradient(smoke.inflow_loc[-1]), 1, 1, 10)))
    return loss, smoke, velocity


sim_grad = field.functional_gradient(simulate, wrt='velocity', get_output=False)

initial_smoke = CenteredGrid(0, extrapolation.BOUNDARY, x=32, y=40, bounds=Box(x=32, y=40))
initial_velocity = StaggeredGrid(math.zeros(batch(inflow_loc=4)), extrapolation.ZERO, x=32, y=40,
                                 bounds=Box(x=32, y=40))

velocity_grad = sim_grad(initial_smoke, initial_velocity)
print(velocity_grad)
```
</details>