### PR TITLE
Minor bibliography adjustments/DOI additions

### DIFF
--- a/paper.bib
+++ b/paper.bib
@@ -3,6 +3,7 @@
   title={EagerPy: Writing Code That Works Natively with PyTorch, TensorFlow, JAX, and NumPy},
   author={Jonas Rauber and Matthias Bethge and Wieland Brendel},
   year={2020},
+  publisher={{arXiv}},
   eprint={2008.04175},
   archivePrefix={arXiv},
   primaryClass={cs.LG}
@@ -33,7 +34,8 @@
   number={6},
   pages={463--477},
   year={2019},
-  publisher={Nature Publishing Group UK London}
+  publisher={Nature Publishing Group UK London},
+  doi={10.1038/s41573-019-0024-5},
 }
 
 @article{AlphaFold2021,
@@ -44,7 +46,8 @@
   number={7873},
   pages={583--589},
   year={2021},
-  publisher={Nature Publishing Group}
+  publisher={Nature Publishing Group},
+  doi={10.1038/s41586-021-03819-2}
 }
 
 @article{Weather2022,
@@ -91,7 +94,8 @@
   number={3},
   pages={338--358},
   year={2019},
-  publisher={Wiley Online Library}
+  publisher={Wiley Online Library},
+  doi={10.1002/inf2.12028}
 }
 
 
@@ -152,12 +156,13 @@
   number={7715},
   pages={547--555},
   year={2018},
-  publisher={Nature Publishing Group UK London}
+  publisher={Nature Publishing Group UK London},
+  doi={10.1038/s41586-018-0337-2}
 }
 
 
 @article{SolverInTheLoop2020,
-  title={Solver-in-the-loop: Learning from differentiable physics to interact with iterative pde-solvers},
+  title={Solver-in-the-loop: Learning from differentiable physics to interact with iterative PDE-solvers},
   author={Um, Kiwon and Brand, Robert and Fei, Yun Raymond and Holl, Philipp and Thuerey, Nils},
   journal={Advances in Neural Information Processing Systems},
   volume={33},
@@ -247,7 +252,7 @@
 @inproceedings{TensorFlow2016,
   title={Tensorflow: A system for large-scale machine learning},
   author={Abadi, Martin and Barham, Paul and Chen, Jianmin and Chen, Zhifeng and Davis, Andy and Dean, Jeffrey and Devin, Matthieu and Ghemawat, Sanjay and Irving, Geoffrey and Isard, Michael and others},
-  booktitle={12th $\{$USENIX$\}$ symposium on operating systems design and implementation ($\{$OSDI$\}$ 16)},
+  booktitle={12th USENIX symposium on operating systems design and implementation (OSDI 16)},
   pages={265--283},
   year={2016},
   doi={}
@@ -342,6 +347,7 @@
   title={Physics-based Deep Learning},
   author={Nils Thuerey and Philipp Holl and Maximilian Mueller and Patrick Schnell and Felix Trost and Kiwon Um},
   year={2022},
+  publisher={{arXiv}},
   eprint={2109.05237},
   archivePrefix={arXiv},
   primaryClass={cs.LG}
@@ -360,6 +366,7 @@
 @misc{PDEArena,
   title={Towards Multi-spatiotemporal-scale Generalized PDE Modeling},
   author={Jayesh K. Gupta and Johannes Brandstetter},
+  publisher={{arXiv}},
   year={2022},
   eprint={2209.15616},
   archivePrefix={arXiv},
@@ -375,22 +382,26 @@
   year={2021}
 }
 @article{wandel2021teaching,
-  title={Teaching the incompressible Navier--Stokes equations to fast neural surrogate models in three dimensions},
+  title={Teaching the incompressible {Navier--Stokes} equations to fast neural surrogate models in three dimensions},
   author={Wandel, Nils and Weinmann, Michael and Klein, Reinhard},
   journal={Physics of Fluids},
   volume={33},
   number={4},
   year={2021},
   publisher={AIP Publishing},
-  doi={DOI: 10.1063/5.0047428}
+  doi={10.1063/5.0047428}
 }
-@inproceedings{brandstetter2022clifford,
-  title={Clifford Neural Layers for PDE Modeling},
-  author={Brandstetter, Johannes and van den Berg, Rianne and Welling, Max and Gupta, Jayesh K},
-  booktitle={The Eleventh International Conference on Learning Representations},
-  year={2022},
-  doi={10.48550/arXiv.2209.04934}
+
+@misc{brandstetter2023clifford,
+      title={Clifford Neural Layers for PDE Modeling},
+      author={Johannes Brandstetter and Rianne van den Berg and Max Welling and Jayesh K. Gupta},
+      publisher={{arXiv}},
+      year={2023},
+      eprint={2209.04934},
+      archivePrefix={arXiv},
+      primaryClass={cs.LG}
 }
+
 @inproceedings{wandel2020learning,
   title={Learning Incompressible Fluid Dynamics from Scratch-Towards Fast, Differentiable Fluid Models that Generalize},
   author={Wandel, Nils and Weinmann, Michael and Klein, Reinhard},

--- a/paper.md
+++ b/paper.md
@@ -99,7 +99,7 @@ These findings were summarized and formalized in @PBDL2021, along with many addi
 
 The library was also used in network optimization publications, such as showing that inverted simulations can be used to train networks [@ScaleInvariant2022] and that gradient inversion benefits learning the solutions to inverse problems [@HalfInverse2022].
 
-Simulations powered by $\Phi_\textrm{ML}$ have since been used in open data sets [@PDEBench; @PDEArena] and in publications from various research groups [@brandstetter2021message; @wandel2021teaching; @brandstetter2022clifford; @wandel2020learning; @sengar2021multi; @parekh1993sex; @ramos2022control; @wang2022approximately; @wang2022meta; @wang2023applications; @wu2022learning; @li2023latent].
+Simulations powered by $\Phi_\textrm{ML}$ have since been used in open data sets [@PDEBench; @PDEArena] and in publications from various research groups [@brandstetter2021message; @wandel2021teaching; @brandstetter2023clifford; @wandel2020learning; @sengar2021multi; @parekh1993sex; @ramos2022control; @wang2022approximately; @wang2022meta; @wang2023applications; @wu2022learning; @li2023latent].
 
 
 


### PR DESCRIPTION
The only non-trivial change is replacing `brandstetter2022clifford` by `brandstetter2023clifford`, i.e. use the arXiv reference instead of the "International Conference on Learning Representations" reference – I found this more consistent, since you used the arxiv reference for the DOI.