### PR TITLE
fix: widen ravel_multi_index to int64 on overflow

### DIFF
--- a/phiml/backend/_numpy_backend.py
+++ b/phiml/backend/_numpy_backend.py
@@ -362,7 +362,19 @@ class NumPyBackend(Backend):
     def ravel_multi_index(self, multi_index, shape, mode: Union[str, int] = 'undefined'):
         mode = mode if isinstance(mode, int) else {'undefined': 'raise', 'periodic': 'wrap', 'clamp': 'clip'}[mode]
         idx_first = np.transpose(multi_index, (-1,) + tuple(range(self.ndims(multi_index)-1)))
-        result = np.ravel_multi_index(idx_first, shape, mode='wrap' if isinstance(mode, int) else mode).astype(multi_index.dtype)
+        result = np.ravel_multi_index(idx_first, shape, mode='wrap' if isinstance(mode, int) else mode)
+        # Preserve the caller's integer dtype, but widen to int64 when the
+        # linear index space exceeds the dtype's range. Without this, an
+        # int32 multi_index combined with a shape whose product is > 2**31
+        # silently wraps to negative; downstream this surfaces as
+        # `ValueError: index <negative> is out of bounds for array with
+        # size <product>` from np.unravel_index.
+        target_dtype = multi_index.dtype
+        if np.issubdtype(target_dtype, np.integer):
+            max_idx = int(np.prod(shape)) - 1
+            if max_idx > np.iinfo(target_dtype).max:
+                target_dtype = np.int64
+        result = result.astype(target_dtype)
         if isinstance(mode, int):
             outside = self.any((multi_index < 0) | (multi_index >= shape), -1)
             result = self.where(outside, mode, result)

--- a/tests/commit/backend/test__backend.py
+++ b/tests/commit/backend/test__backend.py
@@ -61,6 +61,25 @@ class TestBackends(TestCase):
             flat = b.ravel_multi_index(indices, (1, 2, 3), mode='clamp')
             numpy.testing.assert_equal([0, 0, 2, 3], b.numpy(flat), err_msg=b.name)
 
+    def test_ravel_multi_index_int32_overflow(self):
+        # Regression: int32 multi_index combined with a shape whose product
+        # exceeds 2**31 used to wrap silently and surface as
+        # `ValueError: index <negative> is out of bounds ...` from
+        # np.unravel_index downstream.
+        from phiml.backend._numpy_backend import NUMPY
+        indices = numpy.array([[40000, 40000]], dtype=numpy.int32)
+        shape = (200_000, 200_000)   # product = 4e10 > 2**31
+        flat = NUMPY.ravel_multi_index(indices, shape)
+        expected = 40000 * 200_000 + 40000
+        numpy.testing.assert_equal([expected], flat)
+        # Downstream unravel must round-trip cleanly.
+        numpy.testing.assert_equal([[40000, 40000]], NUMPY.unravel_index(flat, shape))
+        # Small-shape callers still get their input dtype back (no widening
+        # unless overflow would occur).
+        small = numpy.array([[1, 2, 3]], dtype=numpy.int32)
+        small_flat = NUMPY.ravel_multi_index(small, (10, 10, 10))
+        assert small_flat.dtype == numpy.int32, small_flat.dtype
+
     def test_gather(self):
         for b in BACKENDS:
             t = b.zeros((4, 3, 2))


### PR DESCRIPTION
## Summary

`NumpyBackend.ravel_multi_index` unconditionally cast the linearised result to the caller's `multi_index.dtype`. When that dtype was `int32` and the shape product exceeded `2**31`, the cast silently wrapped to negative. Downstream callers — primarily `CompressedSparseMatrix.compress` in `phiml/math/_sparse.py` — then surface it as:

```
ValueError: index <negative> is out of bounds for array with size <product>
```

from `np.unravel_index` on the next line.

Fix: preserve the caller's dtype when it fits, widen to `int64` when `np.prod(shape) > np.iinfo(dtype).max`. The JAX backend already doesn't downcast, so the patch brings the numpy backend in line.

## Reproducer

```python
import numpy as np
from phiml.backend._numpy_backend import NUMPY

indices = np.array([[40000, 40000]], dtype=np.int32)
shape = (200_000, 200_000)   # product = 4e10 > 2**31

lin = NUMPY.ravel_multi_index(indices, shape)
# before this PR:
#   lin.dtype == int32, lin == [-589894592]
#   NUMPY.unravel_index(lin, shape)
#     → ValueError: index -589894592 is out of bounds for array with size 40000000000
# after this PR:
#   lin.dtype == int64, lin == [8000040000]
#   NUMPY.unravel_index(lin, shape) → [[40000, 40000]]   (round-trips)
```

In real use this surfaces in `phi.physics.fluid.make_incompressible` on a 3-D Navier-Stokes grid as soon as `c_dims.volume * u_dims.volume > 2**31` — for an `N³` velocity-on-faces problem, that's around `N ≥ 48`.

## What changed

- `phiml/backend/_numpy_backend.py:362-378` — drop the unconditional `.astype(multi_index.dtype)`, pick `int64` when overflow would occur.
- `tests/commit/backend/test__backend.py` — new `test_ravel_multi_index_int32_overflow` regression case (large-shape round-trip + small-shape dtype preservation).

## Testing done

- New regression test passes.
- `tests/commit/backend/test__backend.py` (43 cases) and `tests/commit/math/test__sparse.py` pass with the patch. One pre-existing failure on `test_convert` (JAX/DLPack GPU issue, unrelated to this PR) was confirmed to also fail on `main`.

Closes #15.